### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,13 @@
+cff-version: 1.2.0
+message: If you use this software, please cite it as below.
+title: '`HAdaptiveIntegration.jl`: Adaptive numerical integration over simplices and orthotopes'
+type: software
+authors:
+- given-names: Luiz
+  family-names: Faria
+  orcid: https://orcid.org/0000-0002-8090-934X
+- given-names: Zoïs
+  family-names: Moitier
+  orcid: https://orcid.org/0000-0003-1736-5754
+repository-code: https://github.com/zmoitier/HAdaptiveIntegration.jl
+license: MIT


### PR DESCRIPTION
Adds a `CITATION.cff` so GitHub shows a "Cite this repository" button and citation tooling can read machine-readable metadata.

Author names and ORCIDs come from `paper.md`, and the licence from the LICENSE file. Validated with `cffconvert --validate` against schema 1.2.0.

Worth checking the given-name/family-name split per author, since some papers give a single `name` field.